### PR TITLE
Update Sonja Lemke's Mastodon account

### DIFF
--- a/fedipol_data.json
+++ b/fedipol_data.json
@@ -1650,10 +1650,10 @@
       "created_at": "2025-07-04T00:00:00.000Z",
       "is_bot": false
     },
-    "https://mastodon.art/@sonjalemke": {
+    "https://ruhr.social/@sonjalemke": {
       "account": {
         "name": "Sonja Lemke",
-        "url": "https://mastodon.art/@sonjalemke",
+        "url": "https://ruhr.social/@sonjalemke",
         "category": "Mitglied des Deutschen Bundestages (Linke)"
       },
       "posts_count": 48,

--- a/politiker-und-institutionen-im-fediverse.md
+++ b/politiker-und-institutionen-im-fediverse.md
@@ -278,7 +278,7 @@
 | Ina Latendorf | https://social.linksfraktion.de/@ina_latendorf |
 | Clara Bünger | https://social.linksfraktion.de/@clarabuenger |
 | Anne-Mieke Bremer | https://mastodon.de/@Koffeinpiratin |
-| Sonja Lemke | https://mastodon.art/@sonjalemke |
+| Sonja Lemke | https://ruhr.social/@sonjalemke |
 | Ines Schwerdtner | https://linke.social/@inesschwerdtner |
 | Jan Köstering | https://ruhr.social/@j_koestering |
 | Cornelia Möhring | https://social.linksfraktion.de/@cornelia_moehring |


### PR DESCRIPTION
It seems that Sonja Lemke still has an active Mastodon account here: https://ruhr.social/@sonjalemke. Therefore replacing the old, deleted account with the current one.

Also see: https://ruhr.social/@sonjalemke/115441032609670424